### PR TITLE
Fix wrong use of peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
     "name": "David Schissler @dschissler"
   },
   "description": "PO loader module for webpack",
-  "peerDependencies": {
-    "po2json": ">=0.4.0"
-  },
   "repository": {
     "type": "git",
     "url": "git@github.com:perchlayer/po-loader.git"
@@ -24,6 +21,7 @@
     "url": "https://github.com/perchlayer/po-loader/issues"
   },
   "dependencies": {
-    "loader-utils": "^1.1.0"
+    "loader-utils": "^1.1.0",
+    "po2json": ">=0.4.0"
   }
 }


### PR DESCRIPTION
Because po2json is explicitly required. I had a weird bug when let as peerDependencies with po2json not installed (npm@6) and webpack crashing at build :/